### PR TITLE
Allow for TypeScript Usage

### DIFF
--- a/@types/base64-tools/index.d.ts
+++ b/@types/base64-tools/index.d.ts
@@ -1,0 +1,1 @@
+declare module "base64-tools";

--- a/@types/base64-tools/package.json
+++ b/@types/base64-tools/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@types/base64-tools",
+  "version": "1.0.1",
+  "description": "Base64 encoding/decoding",
+  "main": "",
+  "types": "index.d.ts",
+  "author": "Roxza",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Roxza/base64.git"
+  },
+  "keywords": [
+    "base64",
+    "imagetobase64",
+    "base64toimage"
+  ],
+  "license": "MIT",
+  "scripts": {},
+  "dependencies": {},
+  "typeScriptVersion": "4.2",
+  "typesVersions": {
+    "<=4.8": {
+      "*": [
+        "ts4.8/*"
+      ]
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,19 +1,30 @@
-const fs = require("fs");
-const mineType = require("mime-types");
+import { readFileSync, writeFile } from "fs";
+import { lookup } from "mime-types";
+
 class base64 {
+  /**
+   * @param {string} path 
+   * @param {any} callback 
+   */
   static encode(path, callback) {
-    const look = mineType.lookup(path);
+    const look = lookup(path);
     const base64 =
-      "data:" + look + ";base64," + fs.readFileSync(path).toString("base64");
+      "data:" + look + ";base64," + readFileSync(path).toString("base64");
     callback(null, base64);
   }
+
+  /**
+   * @param {string} value 
+   * @param {string} name 
+   * @param {any} callback 
+   */
   static decode(value, name, callback) {
     const match = value.match(/^data:image\/([\w+]+);base64,([\s\S]+)/);
-    fs.writeFile(name, match[2], "base64", function (err) {
+    writeFile(name, match[2], "base64", function (err) {
       if (!match) throw new Error("Invalid base64 string");
       callback(err, name);
     });
   }
 }
 
-module.exports = base64;
+export default base64;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "base64-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Base64 encoding/decoding",
   "main": "index.js",
   "author": "Roxza",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Roxza/base64.git"


### PR DESCRIPTION
You may need to separate the `@types/` directory into another npm package for types definitions, not sure how that part works, as I have never uploaded a package to NPM. I tested this on a project of mine, using `patch-package`, and it worked splendidly, with my changes, for TypeScript usage!